### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/AllenDang/imageformat/compare/v0.1.2...v0.1.3) - 2024-12-06
+
+### Other
+
+- Add detect_image_format_path to prelude
+
 ## [0.1.2](https://github.com/AllenDang/imageformat/compare/v0.1.1...v0.1.2) - 2024-12-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "imageformat"
-version = "0.1.2"
+version = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imageformat"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Quick probing of image format without loading the entire file."
 categories = ["multimedia", "multimedia::images"]


### PR DESCRIPTION
## 🤖 New release
* `imageformat`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/AllenDang/imageformat/compare/v0.1.2...v0.1.3) - 2024-12-06

### Other

- Add detect_image_format_path to prelude
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).