### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/AllenDang/imageformat/compare/v0.1.4...v0.1.5) - 2024-12-06
+
+### Other
+
+- Update README, add example code for detect_image_format_path
+
 ## [0.1.4](https://github.com/AllenDang/imageformat/compare/v0.1.3...v0.1.4) - 2024-12-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "imageformat"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "strum",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imageformat"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Quick probing of image format without loading the entire file."
 categories = ["multimedia", "multimedia::images"]


### PR DESCRIPTION
## 🤖 New release
* `imageformat`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/AllenDang/imageformat/compare/v0.1.4...v0.1.5) - 2024-12-06

### Other

- Update README, add example code for detect_image_format_path
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).