### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/AllenDang/imageformat/compare/v0.1.5...v0.2.0) - 2024-12-06
+
+### Other
+
+- Rework the detection algorithm use match instead of for loop to boost the performance
+
 ## [0.1.5](https://github.com/AllenDang/imageformat/compare/v0.1.4...v0.1.5) - 2024-12-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "imageformat"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "strum",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imageformat"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 description = "Quick probing of image format without loading the entire file."
 categories = ["multimedia", "multimedia::images"]


### PR DESCRIPTION
## 🤖 New release
* `imageformat`: 0.1.5 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `imageformat` breaking changes

```
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ImageFormat::Pnm 16 -> 17 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:40
  variant ImageFormat::Psd 17 -> 18 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:42
  variant ImageFormat::Qoi 18 -> 19 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:44
  variant ImageFormat::Tga 19 -> 20 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:46
  variant ImageFormat::Tiff 20 -> 21 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:48
  variant ImageFormat::Vtf 21 -> 22 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:50
  variant ImageFormat::Pnm 16 -> 17 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:40
  variant ImageFormat::Psd 17 -> 18 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:42
  variant ImageFormat::Qoi 18 -> 19 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:44
  variant ImageFormat::Tga 19 -> 20 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:46
  variant ImageFormat::Tiff 20 -> 21 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:48
  variant ImageFormat::Vtf 21 -> 22 in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:50

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant ImageFormat:Pcx in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:38
  variant ImageFormat:Pcx in /tmp/.tmpHCBCUH/imageformat/src/lib.rs:38

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ImageFormat::Unknown, previously in file /tmp/.tmpkunsTK/imageformat/src/lib.rs:54
  variant ImageFormat::Unknown, previously in file /tmp/.tmpkunsTK/imageformat/src/lib.rs:54
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/AllenDang/imageformat/compare/v0.1.5...v0.2.0) - 2024-12-06

### Other

- Rework the detection algorithm use match instead of for loop to boost the performance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).